### PR TITLE
Autocomplete: fixes to API calls

### DIFF
--- a/src/elmAutocomplete.ts
+++ b/src/elmAutocomplete.ts
@@ -6,9 +6,8 @@ export class ElmCompletionProvider implements vscode.CompletionItemProvider {
     return oracle.GetOracleResults(document, position)
       .then((result) => {
         var r = result.map((v, i, arr) => {
-          var ci : vscode.CompletionItem = new vscode.CompletionItem();
+          var ci : vscode.CompletionItem = new vscode.CompletionItem(v.fullName);
           ci.kind = 0;
-          ci.label = v.fullName;
           ci.insertText = v.fullName;
           ci.detail = v.signature;
           ci.documentation = v.comment;

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -21,7 +21,7 @@ export function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elm', configuration))
   ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELM_MODE, new ElmHoverProvider()));
-  ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), ['.'] ))
+  ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'))
 
   // ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 }


### PR DESCRIPTION
Build was failing. Couple of fixes required to the new Autocomplete code. (I think the VS-API might have changed.)