### PR TITLE
Set up Travis build & testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+
+os:
+  - osx
+  - linux
+    
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+    
+install:
+  - npm install
+  - npm run vscode:prepublish
+    
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/sbrink/vscode-elm.svg?branch=master)](https://travis-ci.org/sbrink/vscode-elm)
+
 # Elm support for Visual Studio Code
 
 Elm needs a good IDE. So let's extend VS Code and make developing in [elm](http://elm-lang.org) even more enjoyable. Currently 3 people are actively maintaining/developing this plugin.

--- a/package.json
+++ b/package.json
@@ -136,11 +136,12 @@
   "main": "./out/src/elmMain",
   "scripts": {
     "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
+    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
+    "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
     "typescript": "^1.6.2",
-    "vscode": "0.10.x"
+    "vscode": "^0.10.7"
   },
   "dependencies": {
     "elm-oracle": "^0.2.0"


### PR DESCRIPTION
Following on from #15, this adds the scripts to set up Travis CI.
* Bumps vscode dependency up to 0.10.7 (needed to run tests on the command line)
* Adds an ```npm test``` script
* Adds a ```.travis.yml``` file
* Adds build status badge to ```readme.md```

I don't know if you're already familiar with Travis; if not then you need to create an account at https://travis-ci.org/ (you can log in with your GitHub credentials). Then enable builds for this repository. All future commits and PRs will then have compile steps and tests run against them.

**Note**: the build will currently fail because of a couple of bugs in the existing code; #20 needs to be applied to fix this.