### PR TITLE
Fixed #19 by updating the path of the `elm-oracle` command

### DIFF
--- a/src/elmOracle.ts
+++ b/src/elmOracle.ts
@@ -19,8 +19,8 @@ export function GetOracleResults(document: vscode.TextDocument, position: vscode
       let fn = path.relative(cwd, filename)
       let wordAtPosition = document.getWordRangeAtPosition(position);
       let currentWord: string = document.getText(wordAtPosition);
-      let oracle = pluginPath + path.sep + 'node_modules' + path.sep + '.bin' + path.sep + 'elm-oracle \"' + fn + '\" ' + currentWord;
-
+      let oracle = pluginPath + path.sep + 'node_modules' + path.sep + 'elm-oracle' + path.sep + 'bin' + path.sep + 'elm-oracle \"' + fn + '\" ' + currentWord;
+    
       p = cp.exec('node ' + oracle, { cwd: cwd }, (err: Error, stdout: Buffer, stderr: Buffer) => {
         try {
           if (err) {

--- a/src/elmUtils.ts
+++ b/src/elmUtils.ts
@@ -64,4 +64,4 @@ export function getIndicesOf(searchStr : string, str : string) : number[] {
   return indices;
 }
 
-export const pluginPath = (isWindows ? process.env["USERPROFILE"] : process.env["HOME"]) + path.sep + '.vscode' + path.sep + 'extensions' + path.sep + 'sbrink.elm'
+export const pluginPath = (isWindows ? process.env["USERPROFILE"] : process.env["HOME"]) + path.sep + '.vscode' + path.sep + 'extensions' + path.sep + 'sbrink.elm-0.3.0'


### PR DESCRIPTION
The reason that tooltips aren't showing is that the plugin is using the wrong path to `elm-oracle`.