### PR TITLE
add ElmSymbolProvider for document symbols

### DIFF
--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -6,6 +6,7 @@ import {activateMake} from './elmMake';
 import {ElmDefinitionProvider} from './elmDefinition';
 import {ElmHoverProvider} from './elmInfo';
 import {ElmCompletionProvider} from './elmAutocomplete';
+import {ElmSymbolProvider} from './elmSymbol';
 import {configuration} from './elmConfiguration';
 
 const ELM_MODE: vscode.DocumentFilter = { language: 'elm', scheme: 'file' };
@@ -21,7 +22,8 @@ export function activate(ctx: vscode.ExtensionContext) {
 
   ctx.subscriptions.push(vscode.languages.setLanguageConfiguration('elm', configuration))
   ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELM_MODE, new ElmHoverProvider()));
-  ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'))
+  ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'));
+  ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ELM_MODE, new ElmSymbolProvider()));
 
   // ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 }

--- a/src/elmSymbol.ts
+++ b/src/elmSymbol.ts
@@ -1,0 +1,154 @@
+import * as vscode from 'vscode';
+import { Position, Range, SymbolInformation, SymbolKind, TextDocument, TextLine } from 'vscode';
+
+export class ElmSymbolProvider implements vscode.DocumentSymbolProvider {
+
+  provideDocumentSymbols = (doc: TextDocument, _) =>
+    Promise.resolve(processDocument(doc));
+}
+
+function processDocument(doc: TextDocument) {
+
+  const docRange = doc.validateRange(
+    new Range(0, 0, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER))
+
+  return getSymbolsForRange(docRange, /^(?=\S)/m, 0, rootProcessor());
+
+  // -- Helper functions -- //
+
+  /** Tuple type that stores a Range and text associated with that range
+   *  Keeping the 2 values avoids having to call doc.getText(range) for the
+   *  text each time, and also in a couple of cases they differ.
+   */
+  type RangeAndText = [Range, string];
+
+  /** Get the symbols in a range */
+  function getSymbolsForRange
+    (range: Range, splitter: RegExp, splitterLength, subProcessor: RangeProcessor)
+    : SymbolInformation[] {
+    // get the whole text for the range & split it with the splitter
+    const
+      text = doc.getText(range),
+      texts = text.split(splitter);
+
+    // convert split strings into RangeAndText tuples
+    const range_texts: RangeAndText[] = [];
+    for (let p = doc.offsetAt(range.start), i = 0; i < texts.length; i++) {
+      const
+        text = texts[i],
+        startPos = doc.positionAt(p),
+        endPos = doc.positionAt(p + text.length);
+      range_texts.push([new Range(startPos, endPos), text]);
+      p += text.length + splitterLength;
+    }
+
+    // process these tuples to extract symbols
+    const symbols = range_texts
+      // concatMap
+      .map(range_text => {
+        const [range, text] = trimRange(range_text);
+        return subProcessor([range, text]);
+      })
+      .reduce((acc, x) => acc.concat(x), [])
+
+    return symbols
+  }
+
+  /** A function that processes a range into a array or zero or more symbols */
+  type RangeProcessor = (rt: RangeAndText) => SymbolInformation[];
+
+  /** Takes the first word of the given text as the name and creates a symbol
+   *  with the given kind
+   */
+  function defaultProcessor(kind: SymbolKind): RangeProcessor {
+    return function([range, text]: [Range, string]): SymbolInformation[] {
+      const
+        // this RegExp could be improved
+        nameMatch = text.match(/^(([\w']+)|\(.*?\))\s*/),
+        name = nameMatch && nameMatch[0];
+      // Filter out type annotations too
+      if (name && text.substr(name.length).charAt(0) !== ':') {
+        return [new SymbolInformation(name.trim(), kind, range)]
+      }
+      else {
+        return []
+      }
+    }
+  }
+
+  /** For ignoring the range eg import, infix, ... */
+  function ignoreProcessor(_) {
+    return [];
+  }
+
+  /** Processes module... statements. Extends the range to the whole document */
+  function moduleProcessor([range, text]) {
+    return defaultProcessor(SymbolKind.Module)
+      ([new Range(range.start, docRange.end), text])
+  }
+
+  /** Processor for ranges found at the top level of the document.
+   *  Processes according to type of statement
+   */
+  function rootProcessor(): RangeProcessor {
+
+    const types: [string, RangeProcessor][] = [
+      ['module ', moduleProcessor],
+      ['type alias ', defaultProcessor(SymbolKind.Class)],
+      ['type ', typeProcessor],
+      ['port ', defaultProcessor(SymbolKind.Interface)],
+      ['import ', ignoreProcessor],
+      ['infix ', ignoreProcessor],
+      ['infixl ', ignoreProcessor],
+      ['infixr ', ignoreProcessor],
+      ['', defaultProcessor(SymbolKind.Variable)],
+    ];
+
+    return function([range, text]) {
+      for (let [prefix, processor] of types) {
+        if (text.startsWith(prefix)) {
+          return processor([range, text.substr(prefix.length).trim()])
+        }
+      }
+    }
+  }
+
+  /** For type ... statements. Splits rest of text by | to create s symbol
+   *  for each constructor
+   */
+  function typeProcessor([range, text]: RangeAndText) {
+    const
+      symbols = defaultProcessor(SymbolKind.Class)([range, text]),
+      allText = doc.getText(range),
+      equalPos = allText.indexOf('='),
+      childrenStart = doc.positionAt(doc.offsetAt(range.start) + equalPos + 1);
+
+    if (equalPos > -1) {
+      const constructorSymbols = getSymbolsForRange(
+        new Range(childrenStart, range.end),
+        /\|/, 1, defaultProcessor(SymbolKind.Constructor))
+      constructorSymbols.forEach(s => s.containerName = symbols[0].name)
+
+      return symbols.concat(constructorSymbols)
+    }
+    else {
+      return symbols
+    }
+  }
+
+  /** Strip whitespace and comments from start & end of range */
+  function trimRange([range, text]: RangeAndText): RangeAndText {
+    let startOffset = doc.offsetAt(range.start) + text.length;
+    text = text.replace(/^(\s*((--.*)|({-[\s\S]*?-})))*\s*/, "");
+    startOffset -= text.length;
+
+    let endOffset = doc.offsetAt(range.end) - text.length;
+    text = text.replace(/\s+$/, "");
+    endOffset += text.length
+
+    return [
+      new Range(doc.positionAt(startOffset), doc.positionAt(endOffset)),
+      text
+    ];
+  }
+}

--- a/test/elmSymbol.test.ts
+++ b/test/elmSymbol.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { Position, Range, SymbolInformation, SymbolKind, TextDocument, workspace } from 'vscode';
+import { join as pathJoin } from 'path';
+
+import { ElmSymbolProvider } from '../src/elmSymbol'
+
+/** Basic tests for the ElmSymbolProvider to check it's working
+ * and to prevent regressions.
+ */
+suite("elmSymbol", () => {
+
+  const symbolProvider = new ElmSymbolProvider();
+
+  test("Empty file has no symbols", () => {
+    const filePath = pathJoin(__dirname, '../../test/fixtures/src/Empty.elm')
+    const expectedSymbols: SymbolInformation[] = []
+
+    return workspace.openTextDocument(filePath)
+      .then(doc => symbolProvider.provideDocumentSymbols(doc, null))
+      .then(actualSymbols => assert.deepEqual(actualSymbols, expectedSymbols));
+  });
+
+  test("Symbols for document found", () => {
+    const filePath = pathJoin(__dirname, '../../test/fixtures/src/Symbols.elm')
+    const expectedSymbols: SymbolInformation[] = [
+      new SymbolInformation("Module", SymbolKind.Module,
+        new Range(1, 0, 27, 16)),
+      new SymbolInformation("TypeAlias", SymbolKind.Class,
+        new Range(5, 0, 5, 29)),
+      new SymbolInformation("Type", SymbolKind.Class,
+        new Range(7, 0, 7, 39)),
+      new SymbolInformation("Constructor1", SymbolKind.Constructor,
+        new Range(7, 12, 7, 24), undefined, "Type"),
+      new SymbolInformation("Constructor2", SymbolKind.Constructor,
+        new Range(7, 27, 7, 39), undefined, "Type"),
+      new SymbolInformation("function", SymbolKind.Variable,
+        new Range(10, 0, 10, 22)),
+      new SymbolInformation("(%%)", SymbolKind.Variable,
+        new Range(13, 0, 13, 15)),
+      new SymbolInformation("somePort", SymbolKind.Interface,
+        new Range(17, 0, 17, 33)),
+      new SymbolInformation("multiLineFunction", SymbolKind.Variable,
+        new Range(20, 0, 27, 16)),
+    ]
+
+    return workspace.openTextDocument(filePath)
+      .then(doc => symbolProvider.provideDocumentSymbols(doc, null))
+      .then(actualSymbols => {
+        assert.equal(actualSymbols.length, expectedSymbols.length,
+          "Number of found symbols mismatch")
+        expectedSymbols.forEach((ex, i) => {
+          let ac = actualSymbols[i];
+          assert.deepEqual(ac, ex, `Symbol mismatch: ${ac.name}-${ex.name}`)
+        })
+      });
+	});
+});

--- a/test/fixtures/src/Symbols.elm
+++ b/test/fixtures/src/Symbols.elm
@@ -1,0 +1,28 @@
+-- Comments should be ignored
+module Module where
+-- Imports should be ignored
+import Html exposing (..)
+
+type alias TypeAlias = String
+
+type Type = Constructor1 | Constructor2
+
+function : TypeAlias -> TypeAlias
+function ta = ta ++ ta
+
+(%%) : TypeAlias -> TypeAlias
+(%%) = function
+infixr 7 %%
+
+port somePort : Signal Int
+port somePort = Signal.constant 0
+
+multiLineFunction : Type -> String
+multiLineFunction someType =
+  case someType of
+
+    Constructor1 ->
+      "This one"
+
+    Constructor2 ->
+      "That one"


### PR DESCRIPTION
Adds a DocumentSymbolProvider (ElmSymbolProvider) to add the [Go to symbol feature](https://code.visualstudio.com/docs/editor/editingevolved#_goto-symbol) (Ctrl+Shift+O).

<img width="516" alt="go to symbol" src="https://cloud.githubusercontent.com/assets/6125444/12688762/a1d3055e-c6d8-11e5-8fd0-6c3bb41c1e2d.png">

This also lays some groundwork for more autocomplete and go to definition features.