### PR TITLE
ElmLinter: put file name in quotes (fixes #28)

### DIFF
--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -41,7 +41,7 @@ function elmMakeIssueToDiagnostic(issue: IElmIssue): vscode.Diagnostic {
 function checkForErrors(filename): Promise<IElmIssue[]> {
   return new Promise((resolve, reject) => {
     const cwd: string = utils.detectProjectRoot(vscode.window.activeTextEditor) || vscode.workspace.rootPath;
-    let cmd: string = 'elm-make ' + filename + ' --report=json --output /dev/null';
+    let cmd: string = 'elm-make "' + filename + '" --report=json --output /dev/null';
 
     cp.exec(cmd, { cwd: cwd }, (err: Error, stdout: Buffer, stderr: Buffer) => {
       try {


### PR DESCRIPTION
This is a quick fix for file paths with spaces in them being added to the elm-make command for the linter.