### PR TITLE
Fix Reactor on Windows

### DIFF
--- a/src/elmReactor.ts
+++ b/src/elmReactor.ts
@@ -13,8 +13,15 @@ function startReactor(): void {
     const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
     const host: string = <string>config.get('reactorHost');
     const port: string = <string>config.get('reactorPort');
-    reactor = cp.spawn('elm', ['reactor', '-a=' + host, '-p=' + port], { cwd: vscode.workspace.rootPath,
-                                                                         detached: !isWindows });
+    const args = ['-a=' + host, '-p=' + port], cwd = vscode.workspace.rootPath;
+    
+    if (isWindows) {
+      reactor = cp.exec('elm-reactor ' + args.join(' '), { cwd: cwd });
+    }
+    else {
+      reactor = cp.spawn('elm-reactor', args, { cwd: cwd, detached: true });
+    }
+    
     reactor.stdout.on('data', (data: Buffer) => {
       if (data && data.toString().startsWith('| ') === false) {
         oc.append(data.toString());

--- a/test/elmReactor.test.ts
+++ b/test/elmReactor.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert'
+import { commands } from 'vscode';
+import { execCmd, isWindows } from '../src/elmUtils';
+
+suite("ElmReactor", () => { 
+  test("Starts & stops Elm Reactor", function() { 
+    this.timeout(10000);
+    
+    return commands.executeCommand('elm.reactorStart')
+      .then(wait(3000))
+      .then(() => checkForProcess('elm-reactor', true))
+      .then(() => commands.executeCommand('elm.reactorStop'))
+      .then(wait(3000))
+      .then(() => checkForProcess('elm-reactor', false))
+  })
+})
+
+/** setTimeout as a promise */
+const wait = (ms: number) => <T>(value: T) =>
+  new Promise<T>(resolve => setTimeout(() => resolve(value), ms));
+
+/** Check if process is running or not */
+function checkForProcess(processName, isRunning) {
+  const
+    cmd = isWindows ? 'tasklist' : 'ps -axc -o comm',
+    expected = isRunning ? 1 : 0;
+  
+  return execCmd(cmd).then(({stdout}) => {
+    const matches = stdout.split('\n')
+      .filter(line => line.startsWith(processName))
+      .length;
+    assert.equal(matches, expected,
+      `${expected} ${processName} should be running`);
+  });
+}


### PR DESCRIPTION
Starting Reactor wouldn't work on Windows if Elm was installed via NPM. This fixes that issue.