### PR TITLE
Add support for elm-format (fixes #32)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/elmFormat.ts
+++ b/src/elmFormat.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode'
+import { Range, TextEdit } from 'vscode'
+
+import { execCmd } from './elmUtils' 
+
+export class ElmFormatProvider implements vscode.DocumentFormattingEditProvider {
+  
+  provideDocumentFormattingEdits(
+    document: vscode.TextDocument,
+    options: vscode.FormattingOptions,
+    token: vscode.CancellationToken)
+    : Thenable<TextEdit[]>
+  {
+    const format = execCmd('elm-format --stdin');
+    
+    format.stdin.write(document.getText());
+    format.stdin.end();
+    
+    return format
+      .then(({ stdout }) => {
+        const wholeDocument = new Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE);
+        return [TextEdit.replace(wholeDocument, stdout)];
+      })
+      .catch((err) => { 
+        const message = (<string>err.message).includes('SYNTAX PROBLEM')
+          ? "Running elm-format failed. Check the file for syntax errors."
+          : "Running elm-format failed. Install from "
+          + "https://github.com/avh4/elm-format and make sure it's on your path";
+        
+        return vscode.window.showErrorMessage(message).then(() => [])
+      })
+  }
+}

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -9,6 +9,7 @@ import {ElmHoverProvider} from './elmInfo';
 import {ElmCompletionProvider} from './elmAutocomplete';
 import {ElmSymbolProvider} from './elmSymbol';
 import {configuration} from './elmConfiguration';
+import {ElmFormatProvider} from './elmFormat';
 
 const ELM_MODE: vscode.DocumentFilter = { language: 'elm', scheme: 'file' };
 
@@ -26,6 +27,7 @@ export function activate(ctx: vscode.ExtensionContext) {
   ctx.subscriptions.push(vscode.languages.registerHoverProvider(ELM_MODE, new ElmHoverProvider()));
   ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(ELM_MODE, new ElmCompletionProvider(), '.'));
   ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(ELM_MODE, new ElmSymbolProvider()));
+  ctx.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(ELM_MODE, new ElmFormatProvider()))
 
   // ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(ELM_MODE, new ElmDefinitionProvider()));
 }

--- a/src/elmRepl.ts
+++ b/src/elmRepl.ts
@@ -9,7 +9,7 @@ function startRepl(fileName: string, forceRestart = false)
   : Promise<(data: string) => void> {
 
   if (repl.isRunning) {
-    return Promise.resolve(repl.writeToInput);
+    return Promise.resolve(repl.stdin.write.bind(repl.stdin));
   }
   else {
     return new Promise((resolve) => {
@@ -18,7 +18,7 @@ function startRepl(fileName: string, forceRestart = false)
         {
           fileName: fileName,
           showMessageOnError: true,
-          onStart: () => resolve(repl.writeToInput),
+          onStart: () => resolve(repl.stdin.write.bind(repl.stdin)),
           
           // strip output text of leading '>'s and '|'s
           onStdout: (data) => oc.append(data.replace(/^((>|\|)\s*)+/mg, "")),

--- a/src/elmUtils.ts
+++ b/src/elmUtils.ts
@@ -27,8 +27,8 @@ export interface ExecCmdOptions {
  *  and also a wrapper to access ChildProcess-like methods.
  */
 export interface ExecutingCmd extends Promise<{ stdout: string, stderr: string }> {
-  /** Send data to the process's stdin */
-  writeToInput(data: string): void,
+  /** The process's stdin */
+  stdin: NodeJS.WritableStream
   /** End the process */
   kill(),
   /** Is the process running */
@@ -91,7 +91,7 @@ export function execCmd
       }
     }
   });
-  executingCmd.writeToInput = childProcess.stdin.write.bind(childProcess.stdin);
+  executingCmd.stdin = childProcess.stdin;
   executingCmd.kill = killProcess;
   executingCmd.isRunning = true;
 


### PR DESCRIPTION
Adds support for formatting with elm-format (#32).

Uses vscode's "Format Code" command (```Alt+Shift+f```)

Will use elm-format if it's found on the user's path; otherwise with give an error message if they try to use this function (elm-format is still in alpha & doesn't have a distribution yet so I think this is the best way to do it for now).