### PR TITLE
Crashes fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/src",
+			"outDir": "${workspaceRoot}/out/src",
 			"preLaunchTask": "npm"
 		},
 		{
@@ -21,7 +21,7 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "out/test",
+			"outDir": "${workspaceRoot}/out/test",
 			"preLaunchTask": "npm"
 		}
 	]

--- a/src/elmConfiguration.ts
+++ b/src/elmConfiguration.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
 
 export const configuration: vscode.LanguageConfiguration = {
-  wordPattern: /\w*[\.\w+]*/g //THIS PROBABLY SHOULD BE UPDATED
+  wordPattern: /\w+[\.\w+]*/ //THIS PROBABLY SHOULD BE UPDATED
 }


### PR DESCRIPTION
Small fix to languageConfiguration wordPattern (which could match on an empty string and causes crashes in vscode 0.10.10)

Possibly a fix to #41 though not certain.