### PR TITLE
Support the new 0.17 syntax for declaring a module

### DIFF
--- a/syntaxes/elm.json
+++ b/syntaxes/elm.json
@@ -31,7 +31,7 @@
           "name": "keyword.other.elm"
         }
       },
-      "end": "\\b(where)\\b",
+      "end": "\\b(where|exposing)\\b",
       "endCaptures": {
         "1": {
           "name": "keyword.other.elm"


### PR DESCRIPTION
```
module Queue (..) where
```

is now written as

```
module Queue exposing (..)
```

in Elm 0.17.  This PR supports the new syntax (whilst keeping support for the old syntax too).