### PR TITLE
Fix Elm 0.17 module syntax

### DIFF
--- a/syntaxes/elm.json
+++ b/syntaxes/elm.json
@@ -44,7 +44,7 @@
         },
         {
           "match": "(exposing)",
-          "name": "keyword.import.elm"
+          "name": "keyword.other.elm"
         },
         {
           "include": "#module_exports"

--- a/syntaxes/elm.json
+++ b/syntaxes/elm.json
@@ -31,7 +31,7 @@
           "name": "keyword.other.elm"
         }
       },
-      "end": "\\b(where|exposing)\\b",
+      "end": "\\b(where)\\b|$|;",
       "endCaptures": {
         "1": {
           "name": "keyword.other.elm"
@@ -41,6 +41,10 @@
       "patterns": [
         {
           "include": "#module_name"
+        },
+        {
+          "match": "(exposing)",
+          "name": "keyword.import.elm"
         },
         {
           "include": "#module_exports"


### PR DESCRIPTION
PR #17 by already added support for the upcoming 0.17 syntax
for module declarations:

```elm
module Queue exposing (..)
```

It seems however that the part `exposing (..)` is optional.
Here we amend the grammar to fix this.