### PR TITLE
Recognise 0.17 port and effect modules

### DIFF
--- a/syntaxes/elm.json
+++ b/syntaxes/elm.json
@@ -25,7 +25,7 @@
       "name": "constant.language.empty-list.elm"
     },
     {
-      "begin": "^\\b(module)\\s+",
+      "begin": "^\\b((port |effect )?module)\\s+",
       "beginCaptures": {
         "1": {
           "name": "keyword.other.elm"


### PR DESCRIPTION
This adds port and effect module definitions to the syntax file for:

`port module MyModule ...` and `effect module MyModule ...`