### PR TITLE
Fix issue with duplicate content after elm-format on v1.1.0

### DIFF
--- a/src/elmFormat.ts
+++ b/src/elmFormat.ts
@@ -18,7 +18,7 @@ export class ElmFormatProvider implements vscode.DocumentFormattingEditProvider 
     
     return format
       .then(({ stdout }) => {
-        const wholeDocument = new Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE);
+        const wholeDocument = new Range(0, 0, document.lineCount, document.getText().length);
         return [TextEdit.replace(wholeDocument, stdout)];
       })
       .catch((err) => { 


### PR DESCRIPTION
It doesn't seem passing `Number.MAX_VALUE` in the range for `TextEdit.replace` method works anymore after updating to vscode v1.1.0. Using the actual line count and length seems to be working.

This PR fix this duplicate content issue #54  