### PR TITLE
Fix Windows compatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
         "title": "Elm: Make"
       },
       {
+        "command": "elm.makeWarn",
+        "title": "Elm: Make --warn"
+      },
+      {
         "command": "elm.install",
         "title": "Elm: Install packages/dependencies"
       }

--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -42,7 +42,14 @@ function elmMakeIssueToDiagnostic(issue: IElmIssue): vscode.Diagnostic {
 function checkForErrors(filename): Promise<IElmIssue[]> {
   return new Promise((resolve, reject) => {
     const cwd: string = utils.detectProjectRoot(filename) || vscode.workspace.rootPath;
-    const make: cp.ChildProcess = cp.spawn('elm-make', [filename, '--report', 'json', '--output', '/dev/null'], { cwd: cwd });
+    let make: cp.ChildProcess;
+    const args = [filename, '--report', 'json', '--output', '/dev/null'];
+    if (utils.isWindows) {
+      make = cp.exec('elm-make ' + args.join(' '), { cwd: cwd });
+    }
+    else {
+      make = cp.spawn('elm-make', args, { cwd: cwd });
+    }
     // output is actually optional
     // (fixed in https://github.com/Microsoft/vscode/commit/b4917afe9bdee0e9e67f4094e764f6a72a997c70,
     // but unreleased at this time)

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -3,6 +3,7 @@ import {runLinter} from './elmLinter';
 import {activateRepl} from './elmRepl';
 import {activateReactor, deactivateReactor} from './elmReactor';
 import {activateMake} from './elmMake';
+import {activateMakeWarn} from './elmMakeWarn';
 import {activatePackage} from './elmPackage';
 import {ElmDefinitionProvider} from './elmDefinition';
 import {ElmHoverProvider} from './elmInfo';

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -18,7 +18,13 @@ function runMake(editor : vscode.TextEditor) : void {
     const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
     const name: string = <string>config.get('makeOutput');
     const cwd: string = utils.detectProjectRoot(file) || vscode.workspace.rootPath;
-    make = cp.spawn('elm-make', [file,'--yes', '--output=' + name], {cwd: cwd})
+    const args = [file, '--yes', '--output=' + name];
+    if (utils.isWindows) {
+      make = cp.exec('elm-make ' + args.join(' '), { cwd: cwd });
+    }
+    else {
+      make = cp.spawn('elm-make', args, { cwd: cwd });
+    }
     make.stdout.on('data', (data: Buffer) => {
       if (data) {
         oc.append(data.toString());

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -5,7 +5,7 @@ import * as utils from './elmUtils';
 let make: cp.ChildProcess;
 let oc: vscode.OutputChannel = vscode.window.createOutputChannel('Elm Make');
 
-function runMake(editor : vscode.TextEditor) : void {
+function execMake(editor : vscode.TextEditor, warn : boolean) : void {
   try {
     if (editor.document.languageId !== 'elm') {
       return;
@@ -18,7 +18,10 @@ function runMake(editor : vscode.TextEditor) : void {
     const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
     const name: string = <string>config.get('makeOutput');
     const cwd: string = utils.detectProjectRoot(file) || vscode.workspace.rootPath;
-    const args = [file, '--yes', '--output=' + name];
+    let args = [file, '--yes', '--output=' + name];
+    if (warn) {
+      args.push("--warn");
+    }
     if (utils.isWindows) {
       make = cp.exec('elm-make ' + args.join(' '), { cwd: cwd });
     }
@@ -43,7 +46,16 @@ function runMake(editor : vscode.TextEditor) : void {
   }
 }
 
+function runMake(editor: vscode.TextEditor) : void {
+  execMake(editor, false);
+}
+
+function runMakeWarn(editor: vscode.TextEditor) : void {
+  execMake(editor, true);
+}
+
 export function activateMake(): vscode.Disposable[] {
   return [
-    vscode.commands.registerTextEditorCommand('elm.make', runMake)];
+    vscode.commands.registerTextEditorCommand('elm.make', runMake),
+    vscode.commands.registerTextEditorCommand('elm.makeWarn', runMakeWarn)];
 }


### PR DESCRIPTION
Addresses failure of elm: make command and the linter that runs when files are saved for the Windows platform. 

[Related stack overflow post](http://stackoverflow.com/questions/33141736/change-from-child-process-exec-to-spawn-dont-work)