### PR TITLE
Display tooltips as markdown

### DIFF
--- a/src/elmInfo.ts
+++ b/src/elmInfo.ts
@@ -7,7 +7,7 @@ export class ElmHoverProvider implements vscode.HoverProvider {
       .then((result) => {
         if (result.length > 0) {
             let text = result[0].signature + '\n\n' + result[0].comment;
-            let hover = new vscode.Hover({ language: 'elm', value: text });
+            let hover = new vscode.Hover(text);
             return hover;
         }
         else {


### PR DESCRIPTION
This prevents elm code from being highlighted correctly (type signature of the function in tooltip that is generated). That being said, the documentation being displayed *is* markdown, and should be displayed as such.