### PR TITLE
Adds config for custom make command

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
           "type": "string",
           "default": "elm.js",
           "description": "Elm Make's output file name (relative to root folder)"
+        },
+        "elm.makeCommand": {
+          "type": "string",
+          "default": "elm-make",
+          "description": "Command to run when executing elm-make"
         }
       }
     },

--- a/src/elmLinter.ts
+++ b/src/elmLinter.ts
@@ -41,14 +41,16 @@ function elmMakeIssueToDiagnostic(issue: IElmIssue): vscode.Diagnostic {
 
 function checkForErrors(filename): Promise<IElmIssue[]> {
   return new Promise((resolve, reject) => {
+    const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
+    const makeCommand: string = <string>config.get('makeCommand');
     const cwd: string = utils.detectProjectRoot(filename) || vscode.workspace.rootPath;
     let make: cp.ChildProcess;
     const args = [filename, '--report', 'json', '--output', '/dev/null'];
     if (utils.isWindows) {
-      make = cp.exec('elm-make ' + args.join(' '), { cwd: cwd });
+      make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
     }
     else {
-      make = cp.spawn('elm-make', args, { cwd: cwd });
+      make = cp.spawn(makeCommand, args, { cwd: cwd });
     }
     // output is actually optional
     // (fixed in https://github.com/Microsoft/vscode/commit/b4917afe9bdee0e9e67f4094e764f6a72a997c70,

--- a/src/elmMake.ts
+++ b/src/elmMake.ts
@@ -17,16 +17,17 @@ function execMake(editor : vscode.TextEditor, warn : boolean) : void {
     const file = editor.document.fileName
     const config: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration('elm');
     const name: string = <string>config.get('makeOutput');
+    const makeCommand: string = <string>config.get('makeCommand');
     const cwd: string = utils.detectProjectRoot(file) || vscode.workspace.rootPath;
     let args = [file, '--yes', '--output=' + name];
     if (warn) {
       args.push("--warn");
     }
     if (utils.isWindows) {
-      make = cp.exec('elm-make ' + args.join(' '), { cwd: cwd });
+      make = cp.exec(makeCommand + ' ' + args.join(' '), { cwd: cwd });
     }
     else {
-      make = cp.spawn('elm-make', args, { cwd: cwd });
+      make = cp.spawn(makeCommand, args, { cwd: cwd });
     }
     make.stdout.on('data', (data: Buffer) => {
       if (data) {


### PR DESCRIPTION
My main use case for this was to be able to configure the extension to use a locally installed elm package instead of defaulting to a globally installed elm package.

We are still on 0.16 at work, but I use 0.17 for personal projects. This makes it possible to use both.