### PR TITLE
AutoComplete enhancement: name vs. fullName

### DIFF
--- a/src/elmAutocomplete.ts
+++ b/src/elmAutocomplete.ts
@@ -3,17 +3,20 @@ import * as oracle from './elmOracle'
 
 export class ElmCompletionProvider implements vscode.CompletionItemProvider {
   public provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Thenable<vscode.CompletionItem[]> {
+    let wordRange = document.getWordRangeAtPosition(position);
+    let currentWord: string = document.getText(wordRange);
+
     return oracle.GetOracleResults(document, position)
       .then((result) => {
         var r = result.map((v, i, arr) => {
-          var ci : vscode.CompletionItem = new vscode.CompletionItem(v.fullName);
+          var ci: vscode.CompletionItem = new vscode.CompletionItem(v.fullName);
           ci.kind = 0;
-          ci.insertText = v.fullName;
+          ci.insertText = v.name.startsWith(currentWord) ? v.name : v.fullName;
           ci.detail = v.signature;
           ci.documentation = v.comment;
           return ci;
         });
         return r;
       });
-    }
+  }
 }

--- a/src/elmMain.ts
+++ b/src/elmMain.ts
@@ -3,7 +3,7 @@ import {runLinter} from './elmLinter';
 import {activateRepl} from './elmRepl';
 import {activateReactor, deactivateReactor} from './elmReactor';
 import {activateMake} from './elmMake';
-import {activateMakeWarn} from './elmMakeWarn';
+//import {activateMakeWarn} from './elmMakeWarn';
 import {activatePackage} from './elmPackage';
 import {activateClean} from './elmClean';
 import {ElmDefinitionProvider} from './elmDefinition';

--- a/src/elmOracle.ts
+++ b/src/elmOracle.ts
@@ -11,6 +11,8 @@ interface IOracleResult {
   comment: string;
 }
 
+let oraclePath = pluginPath + path.sep + 'node_modules' + path.sep + 'elm-oracle' + path.sep + 'bin' + path.sep + 'elm-oracle';
+
 export function GetOracleResults(document: vscode.TextDocument, position: vscode.Position): Thenable<IOracleResult[]> {
   return new Promise((resolve: Function, reject: Function) => {
       let p: cp.ChildProcess;
@@ -19,9 +21,9 @@ export function GetOracleResults(document: vscode.TextDocument, position: vscode
       let fn = path.relative(cwd, filename)
       let wordAtPosition = document.getWordRangeAtPosition(position);
       let currentWord: string = document.getText(wordAtPosition);
-      let oracle = pluginPath + path.sep + 'node_modules' + path.sep + 'elm-oracle' + path.sep + 'bin' + path.sep + 'elm-oracle \"' + fn + '\" ' + currentWord;
+      let oracleCmd = oraclePath + ' "' + fn + '" ' + currentWord;
     
-      p = cp.exec('node ' + oracle, { cwd: cwd }, (err: Error, stdout: Buffer, stderr: Buffer) => {
+      p = cp.exec('node ' + oracleCmd, { cwd: cwd }, (err: Error, stdout: Buffer, stderr: Buffer) => {
         try {
           if (err) {
             return resolve(null);
@@ -32,6 +34,5 @@ export function GetOracleResults(document: vscode.TextDocument, position: vscode
           reject(e);
         }
       });
-      p.stdin.end(document.getText());
     });
 }


### PR DESCRIPTION
As a proposed resolution for #70 the submitted code considers whether the queried token is matching the simple name or the fully qualified name and will choose accordingly.

This change provides no improvement for the `import ... as OtherName` style only for `import ... exposing ...` statements.