### PR TITLE
Add common snippets

### DIFF
--- a/snippets/elm.json
+++ b/snippets/elm.json
@@ -143,12 +143,12 @@
       ],
       "description": "Update record"
     },
-    "Anonumous function": {
+    "Anonymous function": {
       "prefix": "anonymous",
       "body": [
         "(\\ ${argument} -> ${argument} < 0)"
       ],
-      "description": "Anonumous function"
+      "description": "Anonymous function"
     },
     "Union type": {
       "prefix": "union",
@@ -230,13 +230,16 @@
     "Main Program": {
       "prefix": "mainprogram",
       "body": [
+        "--uncomment if needed -- import Html.App as App",
+        "",
         "main : Program Never",
         "main =",
         "  App.program",
-        "    { init = init",
+        "    { init = (model, Cmd Msg)",
         "    , view = view",
         "    , update = update",
         "    , subscriptions = subscriptions",
+        "    }",
         "$1"
       ],
       "description": "Main Program Never"
@@ -249,6 +252,20 @@
         "  ${Sub.none}"
       ],
       "description": "Subscriptions"
-    }
+    },
+	"defaultModel": {
+		"prefix": "elmdmodel",
+		"body": [
+			"type alias Model",
+			"  { statusText : String",
+			"  }",
+			"",
+			"model : Model",
+			"model =",
+			"  { statusText = \"Ready\"",
+			"  }"
+		],
+		"description": "A default model with type declaration"
+	}
   }
 }

--- a/snippets/elm.json
+++ b/snippets/elm.json
@@ -91,6 +91,164 @@
     "Bool -> Bool -> Bool": {
       "prefix": "xor",
       "body": "xor ${1:bool} ${2:bool}"
+    },
+    "Module": {
+      "prefix": "module",
+      "body": [
+        "module ${Name} where",
+        "$1"
+      ],
+      "description": "Module definition"
+    },
+    "Import": {
+      "prefix": "import",
+      "body": [
+        "import ${Name} exposing ($1..)"
+      ],
+      "description": "Unqualified import"
+    },
+    "Case of": {
+      "prefix": "caseof",
+      "body": [
+        "case ${expression} of",
+        "  ${option1} ->",
+        "    $1",
+        "  ${option2} ->",
+        "    $2"
+      ],
+      "description": "Case of expression with 2 alternatives"
+    },
+    "Multi-line comment": {
+      "prefix": "comment",
+      "body": [
+        "{-",
+        "Multi-line comment ",
+        "-}"
+      ],
+      "description": "Multi-line comment"
+    },
+    "Record": {
+      "prefix": "record",
+      "body": [
+        "${recordName} =",
+        "  ${key1} = $1,",
+        "  ${key2} = $2,"
+      ],
+      "description": "Record definition"
+    },
+    "Update record": {
+      "prefix": "recordupdate",
+      "body": [
+        "{ ${recordName} | ${key1} = $1 }"
+      ],
+      "description": "Update record"
+    },
+    "Anonumous function": {
+      "prefix": "anonymous",
+      "body": [
+        "(\\ ${argument} -> ${argument} < 0)"
+      ],
+      "description": "Anonumous function"
+    },
+    "Union type": {
+      "prefix": "union",
+      "body": [
+        "type ${Typename}",
+        "  = ${Value1}",
+        "  | ${Value2}",
+        "  | ${Value2}"
+      ],
+      "description": "Union type"
+    },
+    "Message": {
+      "prefix": "msg",
+      "body": [
+        "type Msg",
+        "  = NoOp",
+        "  | ${Message2}",
+        "  | ${Message3}",
+        "$1"
+      ],
+      "description": "Default message union type"
+    },
+    "Function": {
+      "prefix": "fun",
+      "body": [
+        "${functionName} : ${ArgumentType} -> ${ReturnType}",
+        "${functionName} ${argumentName} =",
+        "  ${--function body here}"
+      ],
+      "description": "Function with type annotation"
+    },
+    "Let expression": {
+      "prefix": "letin",
+      "body": [
+        "let",
+        "  $1",
+        "in",
+        "  $2"
+      ],
+      "description": "Let expression"
+    },
+    "Update function": {
+      "prefix": "update",
+      "body": [
+        "${update} : Msg -> Model -> ( Model, Cmd Msg )",
+        "${update} msg model =",
+        "  case msg of",
+        "    NoOp ->",
+        "      ( model, Cmd.none )",
+        "  case msg of",
+        "    ${option1} ->",
+        "      $1"
+      ],
+      "description": "Default update function"
+    },
+    "View function": {
+      "prefix": "view",
+      "body": [
+        "${view} : Model -> Html Msg",
+        "${view} model =",
+        "  $1"
+      ],
+      "description": "Default view function"
+    },
+    "Incoming port": {
+      "prefix": "portin",
+      "body": [
+        "port ${portName} : (${Typename} -> msg) -> Sub msg"
+      ],
+      "description": "Incoming port"
+    },
+    "Outgoing port": {
+      "prefix": "portout",
+      "body": [
+        "port ${portName} : ${Typename} -> Cmd msg"
+      ],
+      "description": "Outgoing port"
+    },
+    "Main Program": {
+      "prefix": "mainprogram",
+      "body": [
+        "main : Program Never",
+        "main =",
+        "  App.program",
+        "    { init = init",
+        "    , view = view",
+        "    , update = update",
+        "    , subscriptions = subscriptions",
+        "$1"
+      ],
+      "description": "Main Program Never"
+    },
+    "Subscriptions": {
+      "prefix": "subscriptions",
+      "body": [
+        "${subscriptions} : Model -> Sub Msg",
+        "${subscriptions} model =",
+        "  ${Sub.none}"
+      ],
+      "description": "Subscriptions"
     }
   }
 }


### PR DESCRIPTION
I've created some snippets that I find useful when programming in Elm. Do you think these can fit into vscode-elm? It's ok if you just want to use some of them. If not - should I put the snippets in a separate package?