### PR TITLE
Add documentation for the formatOnSave option

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
           "type": "string",
           "default": "elm-make",
           "description": "Command to run when executing elm-make"
+        },
+        "elm.formatOnSave": {
+          "type": "boolean",
+          "default": false,
+          "description": "Runs elm-format on the file every time it is saved"
         }
       }
     },


### PR DESCRIPTION
`formatOnSave` is mentioned in the README, but isn't listed in the default settings within VS Code.