### PR TITLE
Update module snippet for Elm 0.18

### DIFF
--- a/snippets/elm.json
+++ b/snippets/elm.json
@@ -95,7 +95,7 @@
     "Module": {
       "prefix": "module",
       "body": [
-        "module ${Name} where",
+        "module ${Name} exposing ($1..)",
         "$1"
       ],
       "description": "Module definition"


### PR DESCRIPTION
Adjust the module snippet to use elm 0.18 syntax(`where` -> `exposing (..)`)
Commit for reference: https://github.com/elm-lang/elm-compiler/commit/ff0b05b279b567e32c6e11f941cff8c0f654443c