### PR TITLE
Added Elm installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ Elm needs a good IDE. So let's extend VS Code and make developing in [elm](http:
 ![Error highlighting](images/errorHighlighting.gif)
 
 
+## Elm Installation
+
+### Global Installation
+
+Follow (this guide)[https://guide.elm-lang.org/install.html]
+
+
+### Project (Local) Installation
+
+Run `npm install --save-dev elm`
+
+Then, in `workspace.json`, add the following:
+
+```
+"elm.makeCommand": "./node_modules/.bin/elm-make"
+```
+
 ## Feature overview
 
 * [x] Syntax highlighting


### PR DESCRIPTION
Specifically, the project (local) installation info. Personally, I'm not a fan of global deps, they generally get overlooked when moving a project to a new machine / new dev take-on, etc. and can cause project setup debugging issues... Rant over ;)